### PR TITLE
feat: commentUrl option

### DIFF
--- a/.github/workflows/comment-on-push.yml
+++ b/.github/workflows/comment-on-push.yml
@@ -1,0 +1,18 @@
+name: Test Comment on Push
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  lighthouse-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Run Lighthouse
+      uses: ./
+      with:
+        accessToken: ${{ secrets.LIGHTHOUSE_CHECK_GITHUB_ACCESS_TOKEN }}
+        commentUrl: https://api.github.com/repos/foo-software/lighthouse-check-action/commits/${{ github.sha }}/comments
+        prCommentEnabled: true
+        urls: 'https://www.foo.software'

--- a/README.md
+++ b/README.md
@@ -143,6 +143,13 @@ You can choose from two ways of running audits - "locally" in a dockerized GitHu
     <td><code>undefined</code></td>
   </tr>
   <tr>
+    <td><code>commentUrl</code></td>
+    <td>An endpoint to post comments to. This is only needed if you want to trigger comments on <code>push</code>. A <code>pull_request</code> trigger does not require this to be set. Typically this will be from GitHub's API. Example: <code>https://api.github.com/repos/:owner/:repo/commits/:commit_sha/comments</code>.</td>
+    <td><code>string</code></td>
+    <td><code>both</code></td>
+    <td><code>pull_request</code> triggered actions populate this under the hood by default</td>
+  </tr>
+  <tr>
     <td><code>configFile</code></td>
     <td>A configuration file path in JSON format which holds all options defined here. This file should be relative to the file being interpretted. In this case it will most likely be the root of the repo ("./")</td>
     <td><code>string</code></td>

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,8 @@ inputs:
     description: 'For Slack notifications: A version control branch, typically from GitHub.'
   configFile:
     description: 'A configuration file path in JSON format which holds all options defined here. This file should be relative to the file being interpretted. In this case it will most likely be the root of the repo ("./")'
+  commentUrl:
+    description: "An endpoint to post comments to. This is only needed if you want to trigger comments on 'push'. A 'pull_request' trigger does not require this to be set. Typically this will be from GitHub's API. Example: https://api.github.com/repos/:owner/:repo/commits/:commit_sha/comments."
   emulatedFormFactor:
     description: 'Lighthouse setting only used for local audits. See lighthouse-check NPM module for details.'
   extraHeaders:

--- a/index.js
+++ b/index.js
@@ -23,7 +23,8 @@ const formatInput = input => {
   try {
     const urls = formatInput(core.getInput('urls'));
     const extraHeaders = core.getInput('extraHeaders');
-    const prApiUrl = get(github, 'context.payload.pull_request.url');
+    const commentUrl = core.getInput('commentUrl');
+    const prApiUrl = commentUrl || get(github, 'context.payload.pull_request.url');
 
     const results = await lighthouseCheck({
       author: formatInput(core.getInput('author')),


### PR DESCRIPTION
# Summary

Provides `commentUrl` option for those using `push` trigger as explained in #27.