### PR TITLE
fix: artifact upload

### DIFF
--- a/.github/workflows/extraHeaders.yml
+++ b/.github/workflows/extraHeaders.yml
@@ -8,6 +8,7 @@ jobs:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
       - uses: actions/checkout@master
+      - run: mkdir -p ${{ github.workspace }}/tmp/artifacts
       - uses: amondnet/now-deployment@master
         id: now
         with:

--- a/.github/workflows/extraHeaders.yml
+++ b/.github/workflows/extraHeaders.yml
@@ -20,10 +20,10 @@ jobs:
         with:
           extraHeaders: '{ "x-test-1": "hello world", "x-test-2": "foo" }'
           fooApiToken: ${{ secrets.LIGHTHOUSE_CHECK_API_TOKEN }}
-          outputDirectory: /tmp/artifacts
+          outputDirectory: ${{ github.workspace }}/tmp/artifacts
           urlsJson: '[["cf8b27b3-ccb8-4477-83b6-ded2c375f977", "${{ steps.now.outputs.preview-url }}"]]'
       - name: Upload artifacts
         uses: actions/upload-artifact@master
         with:
           name: Lighthouse reports
-          path: /tmp/artifacts
+          path: ${{ github.workspace }}/tmp/artifacts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
+    - run: mkdir ${{ env.GITHUB_WORKSPACE }}/tmp/artifacts
     - name: Run Lighthouse
       uses: ./
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         gitBranch: ${{ github.ref }}
         gitHubAccessToken: ${{ secrets.LIGHTHOUSE_CHECK_GITHUB_ACCESS_TOKEN }}
         maxRetries: 1
-        outputDirectory: ${{ $GITHUB_WORKSPACE }}/tmp/artifacts
+        outputDirectory: ${{ env.GITHUB_WORKSPACE }}/tmp/artifacts
         urls: 'https://www.foo.software,https://www.foo.software/tag/articles/'
         sha: ${{ github.sha }}
         slackWebhookUrl: ${{ secrets.LIGHTHOUSE_CHECK_WEBHOOK_URL }}
@@ -26,4 +26,4 @@ jobs:
       uses: actions/upload-artifact@master
       with:
         name: Lighthouse reports
-        path: ${{ $GITHUB_WORKSPACE }}/tmp/artifacts
+        path: ${{ env.GITHUB_WORKSPACE }}/tmp/artifacts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - run: mkdir -p ${{ env.GITHUB_WORKSPACE }}/tmp/artifacts
-    - run: echo 'my workspace ${{ env.GITHUB_WORKSPACE }}'
+    - run: mkdir -p ${{ github.workspace }}/tmp/artifacts
     - name: Run Lighthouse
       uses: ./
       with:
@@ -20,7 +19,7 @@ jobs:
         gitBranch: ${{ github.ref }}
         gitHubAccessToken: ${{ secrets.LIGHTHOUSE_CHECK_GITHUB_ACCESS_TOKEN }}
         maxRetries: 1
-        outputDirectory: ${{ env.GITHUB_WORKSPACE }}/tmp/artifacts
+        outputDirectory: ${{ github.workspace }}/tmp/artifacts
         urls: 'https://www.foo.software,https://www.foo.software/tag/articles/'
         sha: ${{ github.sha }}
         slackWebhookUrl: ${{ secrets.LIGHTHOUSE_CHECK_WEBHOOK_URL }}
@@ -28,4 +27,4 @@ jobs:
       uses: actions/upload-artifact@master
       with:
         name: Lighthouse reports
-        path: ${{ env.GITHUB_WORKSPACE }}/tmp/artifacts
+        path: ${{ github.workspace }}/tmp/artifacts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - run: mkdir ${{ env.GITHUB_WORKSPACE }}/tmp/artifacts
+    - run: mkdir -p ${{ env.GITHUB_WORKSPACE }}/tmp/artifacts
     - name: Run Lighthouse
       uses: ./
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - run: mkdir -p ${{ env.GITHUB_WORKSPACE }}/tmp/artifacts
+    - run: echo 'my workspace ${{ env.GITHUB_WORKSPACE }}'
     - name: Run Lighthouse
       uses: ./
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         gitBranch: ${{ github.ref }}
         gitHubAccessToken: ${{ secrets.LIGHTHOUSE_CHECK_GITHUB_ACCESS_TOKEN }}
         maxRetries: 1
-        outputDirectory: /tmp/artifacts
+        outputDirectory: ${{ $GITHUB_WORKSPACE }}/tmp/artifacts
         urls: 'https://www.foo.software,https://www.foo.software/tag/articles/'
         sha: ${{ github.sha }}
         slackWebhookUrl: ${{ secrets.LIGHTHOUSE_CHECK_WEBHOOK_URL }}
@@ -26,4 +26,4 @@ jobs:
       uses: actions/upload-artifact@master
       with:
         name: Lighthouse reports
-        path: /tmp/artifacts
+        path: ${{ $GITHUB_WORKSPACE }}/tmp/artifacts

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,4 @@ COPY . .
 RUN npm install
 RUN npm run build
 
-# support a standard location for artifacts
-RUN mkdir -p /tmp/artifacts
-
 CMD [ "node", "/dist/index.js" ]

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ For detailed documentation of all inputs and advanced configuration - visit [the
     <td align="center" width="33.3333333333333%">
       <figure>
         <a href="https://lighthouse-check.s3.amazonaws.com/images/github-actions/github-action-lighthouse-check-lighthouse-report.png">
-          <img alt="Lighthouse Check GitHub action HTML report" src="https://lighthouse-check.s3.amazonaws.com/images/github-actions/github-action-lighthouse-check-lighthouse-report.png" />
+          <img alt="Lighthouse Check GitHub action HTML report" src="https://lighthouse-check.s3.amazonaws.com/images/github-actions/lighthouse-report.png" />
         </a>
         <figcaption>
           HTML Reports


### PR DESCRIPTION
# Summary

Update the way we upload artifacts after [v6.0.0](https://github.com/foo-software/lighthouse-check-action/releases/tag/v6.0.0).

Note we use `github.workspace` because [`env.GITHUB_WORKSPACE` appears to be broken](https://github.community/t/github-workspace-variable-empty/137517/2) in that it returns empty.